### PR TITLE
Disabling proxy on main GH Pages site

### DIFF
--- a/banklesscard-xyz/cloudflare/locals.tf
+++ b/banklesscard-xyz/cloudflare/locals.tf
@@ -113,7 +113,7 @@ locals {
       "name"    = "www",
       "value"   = "bankless-card.github.io",
       "ttl"     = 1,
-      "proxied" = true
+      "proxied" = false
     },
     "vault" = {
       "name"    = "vault",
@@ -176,25 +176,25 @@ locals {
       "name"    = "banklesscard.xyz",
       "value"   = "185.199.108.153",
       "ttl"     = 1,
-      "proxied" = true
+      "proxied" = false
     },
     "banklesscard_4" = {
       "name"    = "banklesscard.xyz",
       "value"   = "185.199.109.153",
       "ttl"     = 1,
-      "proxied" = true
+      "proxied" = false
     },
     "banklesscard_2" = {
       "name"    = "banklesscard.xyz",
       "value"   = "185.199.110.153",
       "ttl"     = 1,
-      "proxied" = true
+      "proxied" = false
     },
     "banklesscard_1" = {
       "name"    = "banklesscard.xyz",
       "value"   = "185.199.111.153",
       "ttl"     = 1,
-      "proxied" = true
+      "proxied" = false
     },
     "banklesscard_signup_1" = {
       "name"    = "signup",


### PR DESCRIPTION
Purpose
-------
Debugging BanklessCard not swapping to the new GitHub Pages repo correctly

Changes Made
------------

1. Disable CF proxying on GH Pages for apex domain and `www` CNAME
