### PR TITLE
chore: redirect bankless.community and subdomains hosted by the BanklessDAO Vercel team to the Black Flag DAO Notion page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           cd $HOME
           wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
           unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+          sudo mv terraform /usr/local/bin/
       - name: Setup Python
         uses: actions/setup-python@v2
       - name: Run pre-commit

--- a/bankless-community/cloudflare/locals.tf
+++ b/bankless-community/cloudflare/locals.tf
@@ -70,17 +70,17 @@ locals {
   # Must be unique keys, only the last key will be used.
   # Change to an Object to support more than 1 name (see examples above)
   cname_records = {
-    "www"              = "cname.vercel-dns.com.",
+    "www"              = "blackflagdao.notion.site",
     "forum"            = "bankless.hosted-by-discourse.com.",
-    "join"             = "cname.vercel-dns.com.",
+    "join"             = "blackflagdao.notion.site",
     "academy"          = "cname.vercel-dns.com.",
     "docs"             = "hosting.gitbook.io.",
     "bountyboard"      = "cname.vercel-dns.com.",
     "test-bountyboard" = "cname.vercel-dns.com.",
-    "season2"          = "cname.vercel-dns.com.",
-    "season3"          = "cname.vercel-dns.com.",
-    "season4"          = "cname.vercel-dns.com.",
-    "season5"          = "cname.vercel-dns.com.",
+    "season2"          = "blackflagdao.notion.site",
+    "season3"          = "blackflagdao.notion.site",
+    "season4"          = "blackflagdao.notion.site",
+    "season5"          = "blackflagdao.notion.site",
     "rewards"          = "app.thrivecoin.com",
     "onboarding"       = "cname.vercel-dns.com."
   }
@@ -88,7 +88,7 @@ locals {
   a_records = {
     "apex" = {
       "name"    = "@",
-      "value"   = "76.76.21.21",
+      "value"   = "208.103.161.33",
       "proxied" = false
     },
     "infosec1" = {


### PR DESCRIPTION
Purpose
-------
BanklessDAO has reorganized and rebranded, fully independent from the Bankless brand. We want to redirect the old `bankless.community` domain to the new [Black Flag DAO Notion Site](https://blackflagdao.notion.site/) to aid in the transition. 

Changes Made
------------
* chore: redirect bankless.community and subdomains hosted by the BanklessDAO Vercel team to the Black Flag DAO Notion page.

Details
-----------
* I used https://www.nslookup.io/domains/blackflagdao.notion.site/webservers/ to determine the Notion IP Address.

Considerations
------------
* The tlBank page must continue to be hosted somewhere, and Vercel is the easiest place to host it. Therefore, we cannot eliminate the BanklessDAO Vercel team at this time.
* The BanklessDAO website will continue to be hosted at
  * https://banklessdao-website.vercel.app
  * https://bankless-website-three.vercel.app
* The tlBank page will continue to be hosted at
  * https://banklessdao-website.vercel.app/tlBank
  * https://bankless-website-three.vercel.app/tlBank
* Several subdomains were *not* migrated to the new [Black Flag DAO Notion Site](https://blackflagdao.notion.site/) because they are currently pointing to a different Vercel team, presumably the Bankless Academy Vercel team.

Next Steps
-----------
* Add a link to the [Black Flag DAO Notion Site](https://blackflagdao.notion.site/) back to the new [tlBank page](https://banklessdao-website.vercel.app/tlBank)

Risks
------------
* **Will BanklessHQ allow us to migrate the BanklessDAO website to https://banklessdao-website.vercel.app?**: Bankless HQ has previously used [Dopple](https://www.doppel.com/) to takedown websites impersonating the [Bankless](https://www.bankless.com/) website and brand. They went so far as to accuse a developer preview of the tlBank page, hosted in Cloudflare, of phishing - resulting in @MantisClone's Cloudflare account getting suspended for almost 9 months. Presumably, they made an exception for the BanklessDAO website hosted at https://bankless.community. It's unclear how this exception works - does it whitelist an entire Vercel team, Cloudflare org, or individual domains? The exception seems to have included https://bankless-website-three.vercel.app which has existed for a long time. 